### PR TITLE
[FIX] 통합테스트 중 발견된 Feign 응답 역직렬화 문제 수정

### DIFF
--- a/src/main/java/org/ticketing/reservation/infrastructure/client/PaymentStatusClient.java
+++ b/src/main/java/org/ticketing/reservation/infrastructure/client/PaymentStatusClient.java
@@ -6,9 +6,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.ticketing.reservation.infrastructure.client.dto.PaymentStatusResponse;
 
-@FeignClient(name = "payment-service", url = "${feign.payment-service.url}")
+@FeignClient(name = "payment-service")
 public interface PaymentStatusClient {
 
-    @GetMapping("/internal/payments/{reservationId}/status")
+    @GetMapping("/internal/payments/reservations/{reservationId}/success")
     PaymentStatusResponse getPaymentStatus(@PathVariable UUID reservationId);
+
 }

--- a/src/main/java/org/ticketing/reservation/infrastructure/client/PaymentStatusProviderImpl.java
+++ b/src/main/java/org/ticketing/reservation/infrastructure/client/PaymentStatusProviderImpl.java
@@ -20,9 +20,14 @@ public class PaymentStatusProviderImpl implements PaymentStatusProvider {
     public PaymentStatus getPaymentStatus(UUID reservationId) {
         try {
             PaymentStatusResponse response = paymentStatusClient.getPaymentStatus(reservationId);
-            return response.status();
+            return switch (response.data().status()) {
+                case "SUCCESS" -> PaymentStatus.COMPLETED;
+                case "FAILED", "CANCELED" -> PaymentStatus.FAILED;
+                case "INIT", "IN_PROGRESS" -> PaymentStatus.PENDING;
+                default -> PaymentStatus.UNKNOWN;
+            };
         } catch (Exception e) {
-            log.error("[PaymentStatusProvider] 결제 상태 조회 실패 - reservationId: {}", reservationId, e);
+            log.error("[PaymentStatusProvider] 결제 상태 조회 실패", e);
             return PaymentStatus.UNKNOWN;
         }
     }

--- a/src/main/java/org/ticketing/reservation/infrastructure/client/dto/PaymentStatusResponse.java
+++ b/src/main/java/org/ticketing/reservation/infrastructure/client/dto/PaymentStatusResponse.java
@@ -3,6 +3,10 @@ package org.ticketing.reservation.infrastructure.client.dto;
 import org.ticketing.reservation.domain.service.PaymentStatusProvider.PaymentStatus;
 
 public record PaymentStatusResponse(
-        PaymentStatus status
+        boolean success,
+        String message,
+        PaymentData data,
+        String traceId
 ) {
+    public record PaymentData(String status) {}
 }


### PR DESCRIPTION
### 📎 관련 이슈
- close #23

### 📌 작업 내용
- 통합테스트 중 reservation-service의 Feign 클라이언트가 payment-service 응답을 올바르게 역직렬화하지 못하는 문제 발견 및 수정
- @FeignClient의 불필요한 url="" 속성 제거

### ✨ 변경 사항
- `PaymentStatusResponse`에 payment-service 응답 래퍼 구조(`success`, `data`) 추가
  - 수정 전: `{"status": "SUCCESS"}` 직접 역직렬화 시도 → null로 인한 UNKNOWN 반환
  - 수정 후: `{"success": true, "data": {"status": "SUCCESS"}}` 구조로 정상 역직렬화
- `PaymentStatusClient`에서 `url=""` 속성 제거 → Eureka 로드밸런싱으로 동작하도록 수정

### 📝 리뷰 포인트 (선택)
- TTL 만료 시 스케줄러가 Feign으로 결제 상태 조회 후 COMPLETED면 예매 자동 확정되는 흐름이 정상 동작하는지 확인 부탁드립니다(제가 테스트시 정상 작동으로 나오나 재확인 부탁드립니다)

### 🧠 기타 참고 사항
- 수정 전 동작: TTL 만료 → 결제 상태 조회 → 항상 UNKNOWN → TTL 자연 만료
- 수정 후 동작: TTL 만료 → 결제 상태 조회 → COMPLETED → 예매 confirm 정상 동작

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced payment status client configuration to use default service routing.
  * Improved payment status response parsing and mapping logic with clearer status value conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->