### PR TITLE
[FEAT] reservation availability event

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
-	runtimeOnly 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
+	runtimeOnly 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/ticketing/reservation/application/service/ReservationSeatService.java
+++ b/src/main/java/org/ticketing/reservation/application/service/ReservationSeatService.java
@@ -150,6 +150,7 @@ public class ReservationSeatService {
                 saved.getId(),
                 matchId,
                 savedSeat.getSeatId(),
+                savedSeat.getSeatGradeId(),
                 OffsetDateTime.now()
         ));
 
@@ -185,6 +186,7 @@ public class ReservationSeatService {
                 reservation.getId(),
                 reservation.getMatchId(),
                 canceled.getSeatId(),
+                canceled.getSeatGradeId(),
                 ReservationSeatStatus.CANCELED,
                 OffsetDateTime.now()
         ));

--- a/src/main/java/org/ticketing/reservation/domain/event/payload/ReservationSeatReleasedEvent.java
+++ b/src/main/java/org/ticketing/reservation/domain/event/payload/ReservationSeatReleasedEvent.java
@@ -13,6 +13,7 @@ public record ReservationSeatReleasedEvent(
         UUID reservationId,
         UUID matchId,
         UUID seatId,
+        UUID seatGradeId,
         ReservationSeatStatus reason,
         OffsetDateTime releasedAt
 ) {

--- a/src/main/java/org/ticketing/reservation/domain/event/payload/ReservationSeatReservedEvent.java
+++ b/src/main/java/org/ticketing/reservation/domain/event/payload/ReservationSeatReservedEvent.java
@@ -11,6 +11,7 @@ public record ReservationSeatReservedEvent(
         UUID reservationId,
         UUID matchId,
         UUID seatId,
+        UUID seatGradeId,
         OffsetDateTime reservedAt
 ) {
 }

--- a/src/main/java/org/ticketing/reservation/infrastructure/config/KafkaTopicConfig.java
+++ b/src/main/java/org/ticketing/reservation/infrastructure/config/KafkaTopicConfig.java
@@ -27,6 +27,12 @@ public class KafkaTopicConfig {
     @Value("${topics.reservation.canceled:reservation.canceled}")
     private String reservationCanceledTopic;
 
+    @Value("${topics.reservation.seat.reserved:reservation.seat.reserved}")
+    private String reservationSeatReservedTopic;
+
+    @Value("${topics.reservation.seat.released:reservation.seat.released}")
+    private String reservationSeatReleasedTopic;
+
     @Bean
     public NewTopic reservationConfirmationFailedTopic() {
         return TopicBuilder.name(reservationConfirmationFailedTopic)
@@ -38,6 +44,22 @@ public class KafkaTopicConfig {
     @Bean
     public NewTopic reservationCanceledTopic() {
         return TopicBuilder.name(reservationCanceledTopic)
+                .partitions(partitions)
+                .replicas(replicas)
+                .build();
+    }
+
+    @Bean
+    public NewTopic reservationSeatReservedTopic() {
+        return TopicBuilder.name(reservationSeatReservedTopic)
+                .partitions(partitions)
+                .replicas(replicas)
+                .build();
+    }
+
+    @Bean
+    public NewTopic reservationSeatReleasedTopic() {
+        return TopicBuilder.name(reservationSeatReleasedTopic)
                 .partitions(partitions)
                 .replicas(replicas)
                 .build();

--- a/src/main/java/org/ticketing/reservation/infrastructure/event/ReservationSeatEventPublisherImpl.java
+++ b/src/main/java/org/ticketing/reservation/infrastructure/event/ReservationSeatEventPublisherImpl.java
@@ -1,34 +1,67 @@
 package org.ticketing.reservation.infrastructure.event;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.ticketing.common.event.Events;
 import org.ticketing.reservation.domain.event.ReservationSeatEventPublisher;
 import org.ticketing.reservation.domain.event.payload.ReservationSeatHeldEvent;
 import org.ticketing.reservation.domain.event.payload.ReservationSeatReleasedEvent;
 import org.ticketing.reservation.domain.event.payload.ReservationSeatReservedEvent;
 
+/**
+ * 좌석 단위 이벤트 Kafka 발행 구현체.
+ *
+ * <p>Outbox 패턴을 통해 DB 트랜잭션과 동일한 원자성 안에서 이벤트를 등록한다.
+ * {@link Events#trigger} 호출 시 {@code OutboxEventListener} 가 같은 트랜잭션에
+ * Outbox 레코드를 삽입하고, AFTER_COMMIT 이후 릴레이 스케줄러가 Kafka 로 전송한다.
+ *
+ * <ul>
+ *   <li>{@code reservation.seat.reserved} — 좌석 결제 확정 시 발행, match-service 가 잔여 좌석 수 감소</li>
+ *   <li>{@code reservation.seat.released} — 좌석 취소/만료 시 발행, match-service 가 잔여 좌석 수 증가</li>
+ * </ul>
+ */
 @Slf4j
 @Component
 public class ReservationSeatEventPublisherImpl implements ReservationSeatEventPublisher {
 
+    private static final String DOMAIN_TYPE = "RESERVATION_SEAT";
+
+    @Value("${topics.reservation.seat.reserved:reservation.seat.reserved}")
+    private String seatReservedTopic;
+
+    @Value("${topics.reservation.seat.released:reservation.seat.released}")
+    private String seatReleasedTopic;
+
     @Override
     public void publishHeld(ReservationSeatHeldEvent event) {
-        // TODO: Kafka 연동 시 실제 발행 구현
-        log.info("[이벤트] 좌석 HOLD - reservationSeatId={}, seatId={}, matchId={}",
-                event.reservationSeatId(), event.seatId(), event.matchId());
+        // HOLD 이벤트는 외부 서비스 연동 불필요 — 로그만 기록
+        log.debug("[이벤트] 좌석 HOLD — seatId={}, matchId={}", event.seatId(), event.matchId());
     }
 
     @Override
     public void publishReserved(ReservationSeatReservedEvent event) {
-        // TODO: Kafka 연동 시 실제 발행 구현
-        log.info("[이벤트] 좌석 RESERVED - reservationSeatId={}, seatId={}, matchId={}",
-                event.reservationSeatId(), event.seatId(), event.matchId());
+        Events.trigger(
+                "reservation-seat-reserved-" + event.reservationSeatId(),
+                DOMAIN_TYPE,
+                event.matchId().toString(),         // matchId 기준 파티션 → 같은 경기 이벤트 순서 보장
+                seatReservedTopic,
+                event
+        );
+        log.info("[ReservationSeatReservedEvent] Outbox 등록 — reservationSeatId={}, matchId={}, seatGradeId={}",
+                event.reservationSeatId(), event.matchId(), event.seatGradeId());
     }
 
     @Override
     public void publishReleased(ReservationSeatReleasedEvent event) {
-        // TODO: Kafka 연동 시 실제 발행 구현
-        log.info("[이벤트] 좌석 해제 - reservationSeatId={}, seatId={}, reason={}",
-                event.reservationSeatId(), event.seatId(), event.reason());
+        Events.trigger(
+                "reservation-seat-released-" + event.reservationSeatId(),
+                DOMAIN_TYPE,
+                event.matchId().toString(),
+                seatReleasedTopic,
+                event
+        );
+        log.info("[ReservationSeatReleasedEvent] Outbox 등록 — reservationSeatId={}, matchId={}, seatGradeId={}, reason={}",
+                event.reservationSeatId(), event.matchId(), event.seatGradeId(), event.reason());
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -37,3 +37,9 @@ eureka:
   client:
     register-with-eureka: true
     fetch-registry: true
+
+topics:
+  reservation:
+    seat:
+      reserved: reservation.seat.reserved
+      released: reservation.seat.released

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,3 +10,12 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: http://localhost:18080/realms/ticketing
+
+management:
+  metrics:
+    tags:
+      application: ${spring.application.name}
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus


### PR DESCRIPTION
### 📎 관련 이슈
- close #25 

### 📌 작업 내용
- `ReservationSeatEventPublisher` — 이벤트 발행 인터페이스 (reserved / released)
- `ReservationSeatEventPublisherImpl` — Outbox 패턴 기반 구현체
- `ReservationSeatReservedEvent` — 좌석 확정 이벤트 페이로드
- `ReservationSeatReleasedEvent` — 좌석 해제 이벤트 페이로드 (취소/만료 reason 포함)

수정 파일
- `ReservationSeatService` — 상태 전이 시점에 이벤트 발행 호출 추가
  - RESERVED 전이 → `publishReserved()`
  - CANCELLED/EXPIRED 전이 → `publishReleased()`

### ✨ 변경 사항
- 주요 변경 내용 정리

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
- HOLD 이벤트 미발행 — reservation-service 내부 상태이며 match-service 잔여 좌석과 무관
- Outbox 패턴으로 DB 커밋 전 이벤트 유실 방지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Prometheus metrics support and added health/management endpoints for observability.
  * Introduced dedicated topics and outbox-based publishing for reservation seat events.

* **Improvements**
  * Reservation events now include seat grade information for clearer tracking.
  * Seat lock release during cancellations is deferred until transactions commit; release failures are logged instead of disrupting flow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/reservation-service/pull/26)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->