### PR TITLE
[FEAT] reservation-service: /detail 호출 시 HOLD 좌석 auto-confirm

### DIFF
--- a/src/main/java/org/ticketing/reservation/domain/service/SeatHoldRepository.java
+++ b/src/main/java/org/ticketing/reservation/domain/service/SeatHoldRepository.java
@@ -66,6 +66,17 @@ public interface SeatHoldRepository {
     /** 현재 락 정보 조회 (HOLD 든 RESERVED 든). */
     Optional<SeatHold> find(UUID matchId, UUID seatId);
 
+    /**
+     * 특정 예매의 미확정(HOLD / EXPIRE_PENDING) 좌석 목록 조회.
+     *
+     * <p>{@code holds:{reservationId}} Set 멤버를 순회하여 살아 있는 좌석 키를 반환한다.
+     * {@link #confirm} 으로 RESERVED 전이된 좌석은 Set 에서 제거되므로 결과에 포함되지 않는다.
+     * TTL 이 만료된 키도 자동으로 제외된다.
+     *
+     * @return 활성 HOLD / EXPIRE_PENDING SeatHold 목록 (없으면 빈 리스트)
+     */
+    List<SeatHold> findAllHeldByReservationId(UUID reservationId);
+
     /** 락 해제. cancel/expire 흐름에서 사용. */
     void release(UUID matchId, UUID seatId);
 

--- a/src/main/java/org/ticketing/reservation/infrastructure/redis/RedisSeatHoldRepository.java
+++ b/src/main/java/org/ticketing/reservation/infrastructure/redis/RedisSeatHoldRepository.java
@@ -286,6 +286,32 @@ public class RedisSeatHoldRepository implements SeatHoldRepository {
     }
 
     @Override
+    public List<SeatHold> findAllHeldByReservationId(UUID reservationId) {
+        try {
+            Set<String> members = redisTemplate.opsForSet().members(holdSetKey(reservationId));
+            if (members == null || members.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<SeatHold> result = new java.util.ArrayList<>();
+            for (String member : members) {
+                String[] parts = member.split(":", 2);
+                if (parts.length != 2) continue;
+                try {
+                    UUID matchId = UUID.fromString(parts[0]);
+                    UUID seatId  = UUID.fromString(parts[1]);
+                    find(matchId, seatId).ifPresent(result::add);
+                } catch (IllegalArgumentException ignored) {
+                    log.warn("[Redis] holds Set 멤버 UUID 파싱 실패 — member={}", member);
+                }
+            }
+            return Collections.unmodifiableList(result);
+        } catch (Exception e) {
+            log.warn("[Redis] findAllHeldByReservationId 실패 — reservationId={}", reservationId, e);
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
     public List<String> findExpiredHoldKeys(long maxEpochSeconds) {
         try {
             Set<String> members = redisTemplate.opsForZSet().rangeByScore(

--- a/src/main/java/org/ticketing/reservation/presentation/controller/ReservationSeatController.java
+++ b/src/main/java/org/ticketing/reservation/presentation/controller/ReservationSeatController.java
@@ -16,9 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.ticketing.reservation.application.dto.command.CancelReservationSeatCommand;
-import org.ticketing.reservation.application.dto.command.ConfirmReservationSeatCommand;
 import org.ticketing.reservation.application.dto.command.HoldReservationSeatCommand;
-import org.ticketing.reservation.application.dto.request.ConfirmReservationSeatRequest;
 import org.ticketing.reservation.application.dto.request.HoldReservationSeatRequest;
 import org.ticketing.reservation.application.dto.result.ReservationSeatResult;
 import org.ticketing.reservation.application.service.ReservationSeatService;
@@ -39,18 +37,6 @@ public class ReservationSeatController {
     ) {
         reservationSeatService.holdSeat(
                 new HoldReservationSeatCommand(extractUserId(jwt), request.reservationId(), request.seatId())
-        );
-    }
-
-    // 결제 확정 - DB INSERT (RESERVED)
-    @PostMapping("/confirm")
-    @ResponseStatus(HttpStatus.CREATED)
-    public ReservationSeatResult confirmReservationSeat(
-            @AuthenticationPrincipal Jwt jwt,
-            @RequestBody ConfirmReservationSeatRequest request
-    ) {
-        return reservationSeatService.confirmReservationSeat(
-                new ConfirmReservationSeatCommand(extractUserId(jwt), request.reservationId(), request.seatId())
         );
     }
 

--- a/src/main/java/org/ticketing/reservation/presentation/controller/internal/InternalReservationController.java
+++ b/src/main/java/org/ticketing/reservation/presentation/controller/internal/InternalReservationController.java
@@ -137,6 +137,11 @@ public class InternalReservationController {
      * <p>{@link SeatHoldRepository#confirm} Lua 스크립트가 HOLD/EXPIRE_PENDING 인 경우에만
      * RESERVED 로 전이하고 {@code holds:{reservationId}} Set 에서 제거한다.
      * 두 번째 호출 시 Set 이 비어 있으므로 confirmReservationSeat 를 건너뛴다.
+     *
+     * <h3>부분 실패 처리</h3>
+     * <p>confirm 에 실패한 좌석이 하나라도 있으면 {@code isValid = false} 를 반환해 결제를 차단한다.
+     * 이미 confirm 된 좌석은 DB/Redis 상태를 유지하고, 실패한 좌석은 TTL 자연 만료로 해제된다.
+     * 각 confirm 은 독립 트랜잭션이므로 부분 커밋 롤백은 수행하지 않는다.
      */
     @GetMapping("/{reservationId}/detail")
     public ResponseEntity<InternalReservationDetailResponse> getReservationDetail(
@@ -146,6 +151,7 @@ public class InternalReservationController {
         List<SeatHold> heldSeats = seatHoldRepository.findAllHeldByReservationId(reservationId);
 
         // 2. HOLD 좌석이 있으면 auto-confirm (멱등: 이미 RESERVED 전이된 좌석은 Set에서 제거되어 있음)
+        boolean anyConfirmFailed = false;
         for (SeatHold hold : heldSeats) {
             try {
                 reservationSeatService.confirmReservationSeat(
@@ -156,8 +162,8 @@ public class InternalReservationController {
                         )
                 );
             } catch (Exception e) {
-                // 이미 confirm 되었거나 만료된 경우 무시 (멱등 처리)
-                log.warn("[InternalReservationController] auto-confirm 스킵 — "
+                anyConfirmFailed = true;
+                log.warn("[InternalReservationController] auto-confirm 실패 — "
                         + "reservationId={}, seatId={}, reason={}",
                         reservationId, hold.seatId(), e.getMessage());
             }
@@ -168,13 +174,16 @@ public class InternalReservationController {
                 new GetReservationQuery(reservationId)
         );
 
+        // 4. 유효성 판단: confirm 실패가 하나라도 있으면 isValid = false
         boolean isPending = result.status() == ReservationStatus.PENDING;
         boolean hasSeats = !result.seats().isEmpty();
         boolean allSeatsReservedInRedis = hasSeats && result.seats().stream()
                 .allMatch(seat -> seatHoldRepository.find(result.matchId(), seat.seatId()).isPresent());
 
+        boolean isValid = isPending && allSeatsReservedInRedis && !anyConfirmFailed;
+
         return ResponseEntity.ok(
-                InternalReservationDetailResponse.from(result, isPending && allSeatsReservedInRedis)
+                InternalReservationDetailResponse.from(result, isValid)
         );
     }
 }

--- a/src/main/java/org/ticketing/reservation/presentation/controller/internal/InternalReservationController.java
+++ b/src/main/java/org/ticketing/reservation/presentation/controller/internal/InternalReservationController.java
@@ -1,7 +1,9 @@
 package org.ticketing.reservation.presentation.controller.internal;
 
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,11 +11,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.ticketing.reservation.application.dto.command.ConfirmReservationCommand;
+import org.ticketing.reservation.application.dto.command.ConfirmReservationSeatCommand;
 import org.ticketing.reservation.application.dto.command.ExpireReservationCommand;
 import org.ticketing.reservation.application.dto.query.GetReservationQuery;
 import org.ticketing.reservation.application.dto.result.ReservationResult;
 import org.ticketing.reservation.application.service.ReservationApplicationService;
+import org.ticketing.reservation.application.service.ReservationSeatService;
 import org.ticketing.reservation.domain.model.ReservationStatus;
+import org.ticketing.reservation.domain.model.redis.SeatHold;
 import org.ticketing.reservation.domain.service.SeatHoldRepository;
 import org.ticketing.reservation.presentation.dto.internal.InternalReservationDetailResponse;
 import org.ticketing.reservation.presentation.dto.internal.InternalReservationResponse;
@@ -31,15 +36,17 @@ import org.ticketing.reservation.presentation.dto.response.ReservationResponseDt
  *   <li>POST /{reservationId}/expire  — TTL 만료 후 예매 만료 (스케줄러 호출)</li>
  *   <li>GET  /{reservationId}         — 예매 기본 정보 조회 (payment-service 호출)</li>
  *   <li>GET  /{reservationId}/status  — 결제 전 좌석 유효성 검증 (payment-service 호출)</li>
- *   <li>GET  /{reservationId}/detail  — 예매 상세 + 유효성 (payment-service 호출)</li>
+ *   <li>GET  /{reservationId}/detail  — 예매 상세 + 유효성; HOLD 좌석을 멱등적으로 auto-confirm (payment-service 호출)</li>
  * </ul>
  */
+@Slf4j
 @RestController
 @RequestMapping("/internal/reservations")
 @RequiredArgsConstructor
 public class InternalReservationController {
 
     private final ReservationApplicationService reservationApplicationService;
+    private final ReservationSeatService reservationSeatService;
     private final SeatHoldRepository seatHoldRepository;
 
     // ──────────────────────────────────────────
@@ -78,10 +85,16 @@ public class InternalReservationController {
     }
 
     /**
-     * 결제 전 유효성 검증 — {@code reservation.status == PENDING} 이고
-     * 모든 좌석이 Redis 에 HOLD 상태인지 확인.
+     * 결제 전 유효성 검증.
      *
-     * <p>빈 좌석 목록은 유효하지 않은 것으로 판단한다 (vacuous truth 방지).
+     * <p>아래 두 조건 중 하나라도 충족하면 {@code isValid = true}:
+     * <ol>
+     *   <li>DB 에 PENDING 상태의 예매가 있고, 모든 좌석이 Redis 에 HOLD/EXPIRE_PENDING 상태로 존재</li>
+     *   <li>DB 에 PENDING 상태의 예매가 있고, DB 좌석이 이미 RESERVED 로 전이된 경우
+     *       (auto-confirm 이 이미 수행된 경우)</li>
+     * </ol>
+     *
+     * <p>Redis HOLD 좌석을 기준으로 하므로 {@code /detail} auto-confirm 이전에도 올바르게 동작한다.
      */
     @GetMapping("/{reservationId}/status")
     public ResponseEntity<InternalReservationStatusResponse> getReservationStatus(
@@ -92,40 +105,76 @@ public class InternalReservationController {
         );
 
         boolean isPending = result.status() == ReservationStatus.PENDING;
-        boolean hasSeats = !result.seats().isEmpty();
-        boolean allSeatsHeld = hasSeats && result.seats().stream()
-                .allMatch(seat -> seatHoldRepository
-                        .find(result.matchId(), seat.seatId())
-                        .isPresent());
+
+        // Redis HOLD 좌석 우선 확인 (auto-confirm 이전 단계 지원)
+        List<SeatHold> heldSeats = seatHoldRepository.findAllHeldByReservationId(reservationId);
+        boolean hasHeldSeats = !heldSeats.isEmpty();
+
+        // DB 좌석이 이미 confirm 된 경우도 유효 (auto-confirm 이후 단계)
+        boolean hasDbSeats = !result.seats().isEmpty();
+        boolean allDbSeatsReservedInRedis = hasDbSeats && result.seats().stream()
+                .allMatch(seat -> seatHoldRepository.find(result.matchId(), seat.seatId()).isPresent());
+
+        boolean isValid = isPending && (hasHeldSeats || allDbSeatsReservedInRedis);
 
         return ResponseEntity.ok(
-                InternalReservationStatusResponse.from(reservationId, isPending && allSeatsHeld)
+                InternalReservationStatusResponse.from(reservationId, isValid)
         );
     }
 
     /**
-     * 예매 상세 정보 + 유효성 반환.
+     * 예매 상세 정보 + 유효성 반환. HOLD 좌석을 멱등적으로 auto-confirm 한다.
      *
-     * <p>{@link #getReservationStatus} 와 동일한 유효성 로직을 포함하며,
-     * totalPrice 등 상세 필드를 함께 반환한다.
+     * <h3>처리 흐름</h3>
+     * <ol>
+     *   <li>Redis {@code holds:{reservationId}} Set 에서 미확정(HOLD/EXPIRE_PENDING) 좌석 조회</li>
+     *   <li>존재하는 경우 각 좌석에 대해 {@link ReservationSeatService#confirmReservationSeat} 호출
+     *       — DB insert + seatProvider.fetchSnapshot() + totalPrice 재계산 + HOLD→RESERVED 전이</li>
+     *   <li>confirm 이후 예매 정보를 재조회하여 최신 totalPrice 를 반환</li>
+     * </ol>
+     *
+     * <h3>멱등성</h3>
+     * <p>{@link SeatHoldRepository#confirm} Lua 스크립트가 HOLD/EXPIRE_PENDING 인 경우에만
+     * RESERVED 로 전이하고 {@code holds:{reservationId}} Set 에서 제거한다.
+     * 두 번째 호출 시 Set 이 비어 있으므로 confirmReservationSeat 를 건너뛴다.
      */
     @GetMapping("/{reservationId}/detail")
     public ResponseEntity<InternalReservationDetailResponse> getReservationDetail(
             @PathVariable UUID reservationId
     ) {
+        // 1. 미확정 HOLD 좌석 조회
+        List<SeatHold> heldSeats = seatHoldRepository.findAllHeldByReservationId(reservationId);
+
+        // 2. HOLD 좌석이 있으면 auto-confirm (멱등: 이미 RESERVED 전이된 좌석은 Set에서 제거되어 있음)
+        for (SeatHold hold : heldSeats) {
+            try {
+                reservationSeatService.confirmReservationSeat(
+                        new ConfirmReservationSeatCommand(
+                                hold.userId(),
+                                hold.reservationId(),
+                                hold.seatId()
+                        )
+                );
+            } catch (Exception e) {
+                // 이미 confirm 되었거나 만료된 경우 무시 (멱등 처리)
+                log.warn("[InternalReservationController] auto-confirm 스킵 — "
+                        + "reservationId={}, seatId={}, reason={}",
+                        reservationId, hold.seatId(), e.getMessage());
+            }
+        }
+
+        // 3. 최신 예매 정보 재조회 (totalPrice 반영)
         ReservationResult result = reservationApplicationService.findById(
                 new GetReservationQuery(reservationId)
         );
 
         boolean isPending = result.status() == ReservationStatus.PENDING;
         boolean hasSeats = !result.seats().isEmpty();
-        boolean allSeatsHeld = hasSeats && result.seats().stream()
-                .allMatch(seat -> seatHoldRepository
-                        .find(result.matchId(), seat.seatId())
-                        .isPresent());
+        boolean allSeatsReservedInRedis = hasSeats && result.seats().stream()
+                .allMatch(seat -> seatHoldRepository.find(result.matchId(), seat.seatId()).isPresent());
 
         return ResponseEntity.ok(
-                InternalReservationDetailResponse.from(result, isPending && allSeatsHeld)
+                InternalReservationDetailResponse.from(result, isPending && allSeatsReservedInRedis)
         );
     }
 }


### PR DESCRIPTION
### 📎 관련 이슈
- close #이슈번호

### 📌 작업 내용
결제 요청 시 payment-service가 `/detail`을 조회하면 totalPrice가 항상 0으로 반환되는 문제를 해결했습니다.
`holdSeat()`은 Redis에만 기록하고 DB에 insert하지 않기 때문에, 명시적인 confirm 호출 없이는 totalPrice가 계산되지 않습니다.
클라이언트가 confirm을 직접 호출하는 설계 대신, `/detail` 자체가 HOLD 좌석을 멱등적으로 auto-confirm하도록 서버 내부로 책임을 이동시켰습니다.

### ✨ 변경 사항

**`RedisSeatHoldRepository`**
- `findAllHeldByReservationId()` 구현 추가
- `holds:{reservationId}` Set에서 SMEMBERS로 멤버 조회 → UUID 파싱 → `find()`로 살아있는 SeatHold 수집

**`InternalReservationController`**
- `GET /{id}/detail`: HOLD 좌석을 `ReservationSeatService.confirmReservationSeat()`로 일괄 처리 후 재조회하여 최신 totalPrice 반환
  - 이미 confirm된 좌석은 holds Set에서 제거되어 있으므로 두 번째 호출 시 자동 스킵 (멱등 보장)
  - confirm 도중 예외(이미 만료, 소유자 불일치 등)는 warn 로그 후 계속 진행
- `GET /{id}/status`: DB 좌석 대신 `findAllHeldByReservationId()`로 Redis HOLD 좌석을 확인
  - auto-confirm 이전 단계(`/status` → `/detail` 순)에서도 `isValid: true` 반환 가능

**`ReservationSeatController`**
- `POST /api/reservation-seats/confirm` 엔드포인트 제거
- `confirmReservationSeat()` 서비스 메서드는 `/detail` 내부에서 사용하므로 유지

### 📝 리뷰 포인트
- `/detail` auto-confirm에서 개별 좌석 confirm 실패 시 예외를 잡아 warn 로그만 남기고 계속 진행합니다. 전체 실패로 롤백할지 아니면 현재처럼 부분 성공을 허용할지 의견 부탁드립니다.
- `findAllHeldByReservationId()`는 holds Set 멤버 전체를 순회하므로, 좌석 수가 많은 경우 Redis 왕복 횟수가 증가합니다. 현재 예매당 최대 좌석 수(`MAX_SEAT_PER_RESERVATION`)가 제한되어 있어 실용적 범위 내로 판단했습니다.

### 🧠 기타 참고 사항
- `confirmReservationSeat()`는 내부적으로 `@Transactional`이므로, `/detail`에서 좌석 수만큼 별도 트랜잭션이 발생합니다.
- payment-service → reservation-service 호출 순서: `GET /status` (HOLD 유효성 확인) → `GET /detail` (auto-confirm + totalPrice 조회) → 결제 진행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the public seat confirmation API endpoint.

* **Improvements**
  * New ability to determine active held seats for a reservation, improving validation accuracy.
  * Internal reservation status/validation now prioritizes live held-seat state.
  * Reservation detail retrieval will attempt idempotent auto-confirmation of held seats and reflect results in validity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/reservation-service/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->